### PR TITLE
Fix merge conflict residue in bankomat.py

### DIFF
--- a/bankomat.py
+++ b/bankomat.py
@@ -58,7 +58,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-<<<<<<< Updated upstream
-    
-=======
->>>>>>> Stashed changes


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers
- ensure the script ends with `main()`

## Testing
- `python -m py_compile bankomat.py`

------
https://chatgpt.com/codex/tasks/task_e_68445506bc248327b8b6a71bc040edca